### PR TITLE
prototype. show requests in tooltip for each cell

### DIFF
--- a/src/js/messaging.js
+++ b/src/js/messaging.js
@@ -231,6 +231,9 @@ var matrixSnapshot = function(pageStore, details) {
         collapseBlacklistedDomains: µmuser.popupCollapseBlacklistedDomains,
         diff: [],
         domain: pageStore.pageDomain,
+        // START UGLY TOOLTIP HACK
+        gcbLog: pageStore.gcbLog,
+        // END UGLY TOOLTIP HACK
         has3pReferrer: pageStore.has3pReferrer,
         hasMixedContent: pageStore.hasMixedContent,
         hasNoscriptTags: pageStore.hasNoscriptTags,

--- a/src/js/pagestats.js
+++ b/src/js/pagestats.js
@@ -120,6 +120,7 @@ PageStore.prototype = {
         this.pageUrl = tabContext.normalURL;
         this.pageHostname = tabContext.rootHostname;
         this.pageDomain =  tabContext.rootDomain;
+        this.gcbLog = {};
         this.title = '';
         this.hostnameTypeCells.clear();
         this.domains.clear();
@@ -221,6 +222,42 @@ PageStore.prototype = {
         var hostname = µm.URI.hostnameFromURI(url),
             key = hostname + ' ' + type,
             uids = this.hostnameTypeCells.get(key);
+        // UGLY TOOLTIP HACK START
+        this.gcbLog[hostname] = this.gcbLog[hostname]
+            || {
+                cookie:[],
+                css:[],
+                doc:[],
+                frame:[],
+                image:[],
+                media:[],
+                other:[],
+                script:[],
+                xhr:[]
+            }
+        ;
+        function typeToFeature(t){
+            switch(t){
+                case 'font'          : return 'css';
+                case 'image'         : return 'image';
+                case 'imageset'      : return 'image';
+                case 'main_frame'    : return 'doc';
+                case 'media'         : return 'media';
+                case 'object'        : return 'media';
+                case 'other'         : return 'other';
+                case 'script'        : return 'script';
+                case 'stylesheet'    : return 'css';
+                case 'sub_frame'     : return 'frame';
+                case 'websocket'     : return 'xhr';
+                case 'xmlhttprequest': return 'xhr';
+                default: return t;
+            }
+        }
+        if( this.gcbLog[hostname][typeToFeature(type)].indexOf(url) === -1 ){
+            this.gcbLog[hostname][typeToFeature(type)].push(url);
+        }
+        // UGLY TOOLTIP HACK END
+
         if ( uids === undefined ) {
             this.hostnameTypeCells.set(key, (uids = new Set()));
         } else if ( uids.size > 99 ) {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -475,6 +475,19 @@ function updateMatrixBehavior() {
         while ( j-- ) {
             subdomainRow = subdomainRows.at(j);
             subdomainRow.toggleClass('collapsible', subdomainRow.descendants('.t81,.t82').length === 0);
+            // START UGLY TOOLTIP HACK
+            let domaintxt = subdomainRow.nodes[0].firstChild.textContent;
+            let domainregex = new RegExp('https?:\/\/'+domaintxt);
+            ['cookie', 'css', 'image', 'media', 'script', 'xhr', 'frame', 'other'].forEach(function(item, i){
+                if( domaintxt in matrixSnapshot.gcbLog ){
+                    subdomainRow.nodes[0].children[i+1].title = matrixSnapshot.gcbLog[domaintxt][item].map(
+                        function(url){
+                            return url.replace( domainregex, '' );
+                        }
+                    ).join("\n");
+                }
+            });
+            // END UGLY TOOLTIP HACK
         }
         section.toggleClass('collapsible', subdomainRows.filter('.collapsible').length > 0);
     }


### PR DESCRIPTION
Shows a tooltip popup with a sampling of the (allowed or blocked) requests' path for each cell.


![screenshot](https://i.imgur.com/farpUR8.png)

@gorhill suggestion, in case you want to allow me to suggest this in the main repo so someone can help clean up the implementation.